### PR TITLE
Feat: change password by logged in Gatepass user

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,14 @@
+require("dotenv").config();
 const express = require("express");
 const bodyParser = require("body-parser");
 const morgan = require("morgan");
 const cors = require("cors");
 const dbConnect = require("./src/config/db");
+const { checkAuth } = require("./src/middlewares/checkAuth");
 
-//routes
 const { authRouter } = require("./src/routes/");
 
+const isProduction = process.env.NODE_ENV === "production";
 dbConnect();
 
 const app = express();
@@ -23,6 +25,39 @@ app.get("/", (req, res) => {
 	});
 });
 
+// use auth middleware
+app.use(checkAuth);
+
 app.use("/api/v1/auth", authRouter);
+
+// catch 404 and forward to error handler
+app.use((req, res, next) => {
+	const error = new Error("Not found");
+	error.status = 404;
+	next(error);
+});
+
+// error handler
+app.use((error, req, res, next) => {
+	if (error.status === 404) {
+		return res.status(404).json({
+			errors: { message: "Invalid Request, Resource not found" },
+		});
+	}
+	if (!isProduction) {
+		return res.status(error.status || 500).json({
+			errors: {
+			  message: error.message,
+			  error: error,
+			},
+		});
+	}
+	return res.status(error.status || 500).json({
+		errors: {
+		  message:
+			'Something went wrong, please try again or check back for a fix',
+		},
+	});
+});
 
 module.exports = app;

--- a/src/constants/routesGroup.js
+++ b/src/constants/routesGroup.js
@@ -1,0 +1,7 @@
+const secureRoutes = [
+    "/api/v1/auth/change-password",
+];
+
+module.exports = {
+    secureRoutes,
+};

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -20,8 +20,16 @@ const createJwtToken = payload => {
     );
 };
 
+const verifyJwtToken = token => {
+    return jwt.verify(
+        token,
+        config.JWT_SECRET_KEY
+    );
+};
+
 module.exports = {
     comparePassword,
     hashPassword,
     createJwtToken,
-}
+    verifyJwtToken,
+};

--- a/src/middlewares/checkAuth.js
+++ b/src/middlewares/checkAuth.js
@@ -1,0 +1,48 @@
+const routes = require("../constants/routesGroup");
+const { User } = require("../models");
+const authHelper = require("../helpers/auth");
+
+// middleware to authenticate users accessing secure routes 
+const checkAuth = async (req, res, next) => {
+    if (routes.secureRoutes.includes(req.path)) {
+        if (!req.headers.authorization) {
+            return res.status(412).json({
+                message: "Access denied!! Missing authorization credentials",
+            });
+        }
+
+        let token = req.headers.authorization;
+
+        if (token.startsWith('Bearer ')) {
+            token = token.split(' ')[1];
+        }
+        
+        try {
+            const decoded = authHelper.verifyJwtToken(token);
+            const user = await User.findById(decoded.userId);
+            if (!user) {
+                return res.status(401).json({
+                  message: "You are not authorized to access this route.",
+                });
+            }
+            req.user = user;
+            return next();
+        } catch (error) {
+            console.log("Error from user authentication >>>>> ", error);
+            if (error.name === 'TokenExpiredError') {
+                return res.status(401).json({
+                    error: true,
+                    message: 'Token expired.',
+                });
+            }
+			return next(error);
+        }
+
+    } else {
+        return next();
+    }
+};
+
+module.exports = {
+    checkAuth,
+};

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -52,7 +52,6 @@ const userSignInValidationRules = () => {
 			.notEmpty()
 			.isLength({ min: 6 })
 			.withMessage("Password must have at least 6 characters"),
-		// add custom validation for add_location and security answer
 	];
 };
 
@@ -64,6 +63,25 @@ const resetPasswordValRules = () => {
 			.withMessage("Password must be at least 6 characters long"),
 	];
 };
+
+const changePasswordValRules = () => {
+	return [
+		body("old_password")
+			.notEmpty()
+			.withMessage("Old password field required"),
+		body("new_password")
+			.notEmpty()
+			.withMessage('A new password is required')
+			.isLength({ min: 6 })
+			.withMessage("Password must be at least 6 characters long")
+			.custom((value, { req }) => value !== req.body.old_password)
+			.withMessage("Ensure you enter a new password"),
+		body("confirm_password", "passwords do not match")
+			.exists()
+			.custom((val, { req }) => val === req.body.new_password),
+	];
+};
+
 const validateError = (req, res, next) => {
 	const errors = validationResult(req);
 	if (errors.isEmpty()) {
@@ -81,5 +99,6 @@ module.exports = {
 	userSignUpValidationRules,
 	userSignInValidationRules,
 	resetPasswordValRules,
+	changePasswordValRules,
 	validateError,
 };

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -5,11 +5,13 @@ const {
 	userSignIn,
 	forgotPassword,
 	changePassword,
+	resetPassword,
 } = require("../controllers/auth.controllers");
 const {
 	userSignUpValidationRules,
 	userSignInValidationRules,
 	resetPasswordValRules,
+	changePasswordValRules,
 	validateError,
 } = require("../middlewares/validation");
 
@@ -31,6 +33,13 @@ authRouter.patch(
 	"/reset-password",
 	resetPasswordValRules(),
 	validateError,
+	resetPassword
+);
+
+authRouter.post(
+	"/change-password", 
+	changePasswordValRules(), 
+	validateError, 
 	changePassword
 );
 


### PR DESCRIPTION
**What does this PR do?**
- Gatepass logged in user can update their password on the go without needing to logout first and request for password change
- Fixes #9 

**How should this be manually tested?**
- checkout to this branch `git checkout auth-change-password`
- ensure environment variables are up to date `cp .env.example .env`
- run `npm run devStart`
- test on postman `/api/v1/auth/change-password`

**Any background context you want to provide?**
- I made a little change on the endpoint names for change(loged in user) and reset password

**What is the link to the issue on Github?**

[Issue #9](https://github.com/Elikdev/Gatepass/issues/9)

**Questions:**
- None
If something is unclear or you want some questions to be addressed by your peers, mention them here
