### PR TITLE
Ft modify user add admins

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -9,4 +9,5 @@ module.exports = {
 	JWT_SECRET_KEY: process.env.JWT_SECRET_KEY,
 	GEOLOCSECRET: process.env.IPGEOLOCATIONAPITOKEN,
 	APP_SECRET: process.env.APP_SECRET,
+	INVITE_SECRET: process.env.INVITE_SECRET,
 };

--- a/src/constants/routesGroup.js
+++ b/src/constants/routesGroup.js
@@ -10,6 +10,7 @@ const secureRoutes = [
 const unsecureRoutes = [
 	"/",
 	"/api/v1/auth/register",
+	"/api/v1/auth/register-by-invite",
 	"/api/v1/auth/login",
 	"/api/v1/auth/reset-password",
 	"/api/v1/auth/verify",

--- a/src/helpers/nodemailer.js
+++ b/src/helpers/nodemailer.js
@@ -104,11 +104,19 @@ const passwordResetEmail = async (data, req) => {
 const sendAppAdminInvite = async (userData, ownerData, appData, req) => {
 	const userEmail = userData.email;
 	const userName = userData.fullname;
-	const invitationToken = jwt.sign({ userId: userData._id, appId: appData._id }, EMAIL_SECRET, {
-		expiresIn: "7d",
-	});
+	const invitationToken = jwt.sign(
+		{
+			userId: userData._id,
+			appId: appData._id,
+			orgName: ownerData.organisation.name,
+		},
+		EMAIL_SECRET,
+		{
+			expiresIn: "7d",
+		}
+	);
 
-	const invitationLink = `http:\/\/${req.headers.host}\/api\/v1\/apps\/invitation\/accept?token=${invitationToken}`;
+	const invitationLink = `http:\/\/${req.headers.host}\/api\/v1\/apps\/invitation\/accept?e=${userEmail}&token=${invitationToken}`;
 
 	const msg = {
 		from: EMAIL_ADDRESS,
@@ -120,7 +128,7 @@ const sendAppAdminInvite = async (userData, ownerData, appData, req) => {
 			name: userName,
 			invitationLink,
 			userEmail,
-			orgName: ownerData.organisation_name,
+			orgName: ownerData.organisation.name,
 			appName: appData.app_name,
 		},
 	};

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -51,6 +51,11 @@ const registerByInviteValidationRules = () => {
 		body("security_answer")
 			.notEmpty()
 			.withMessage("Security answer must have at least 8 characters"),
+		check("t")
+			.notEmpty()
+			.withMessage(
+				"You do not have the required information to access this route"
+			),
 	];
 };
 

--- a/src/middlewares/validation.js
+++ b/src/middlewares/validation.js
@@ -1,5 +1,5 @@
 const { check, body, validationResult } = require("express-validator");
-const { User, App } = require("../models/");
+const { User, App, Organisation } = require("../models/");
 
 const userSignUpValidationRules = () => {
 	return [
@@ -23,19 +23,34 @@ const userSignUpValidationRules = () => {
 		body("email").custom(async (value) => {
 			const user = await User.findOne({ email: value });
 			if (user) {
-				return Promise.reject(
-					"Email has already been registered on gatepass"
-				);
+				return Promise.reject("Email has already been registered on gatepass");
 			}
 		}),
 		body("organisation_name").custom(async (value) => {
-			const org = await User.findOne({ organisation_name: value });
+			const org = await Organisation.findOne({ organisation_name: value });
 			if (org) {
 				return Promise.reject(
 					"You cannot register your organisation with that name. It has been taken, try a new name"
 				);
 			}
 		}),
+	];
+};
+
+const registerByInviteValidationRules = () => {
+	return [
+		body("fullname").notEmpty().withMessage("Fullname field cannot be empty"),
+		body("password")
+			.notEmpty()
+			.isLength({ min: 6 })
+			.withMessage("Password must be at least 6 characters long"),
+		body("security_question")
+			.notEmpty()
+			.isLength({ min: 8 })
+			.withMessage("Security question must have at least 8 characters"),
+		body("security_answer")
+			.notEmpty()
+			.withMessage("Security answer must have at least 8 characters"),
 	];
 };
 
@@ -96,9 +111,7 @@ const appRegisterValRules = () => {
 		body("app_name").custom(async (val) => {
 			const app = await App.findOne({ app_name: val });
 			if (app) {
-				return Promise.reject(
-					"App name has been taken. You need to change it"
-				);
+				return Promise.reject("App name has been taken. You need to change it");
 			}
 		}),
 	];
@@ -130,8 +143,7 @@ const viewAllUserAppsRules = () => {
 
 const updateUserAppRules = () => {
 	return [
-		body("app_name")
-			.optional(),
+		body("app_name").optional(),
 		body("description")
 			.optional()
 			.isLength({ min: 10 })
@@ -141,16 +153,13 @@ const updateUserAppRules = () => {
 		body("app_token")
 			.isEmpty()
 			.withMessage("You have no write access to update the app token"),
-	]
+	];
 };
 
 const addAppAdminRules = () => {
 	return [
-		body("email")
-			.notEmpty()
-			.isEmail()
-			.withMessage("Enter a valid email"),
-	]
+		body("email").notEmpty().isEmail().withMessage("Enter a valid email"),
+	];
 };
 
 const validateError = (req, res, next) => {
@@ -168,6 +177,7 @@ const validateError = (req, res, next) => {
 
 module.exports = {
 	userSignUpValidationRules,
+	registerByInviteValidationRules,
 	userSignInValidationRules,
 	resetPasswordValRules,
 	changePasswordValRules,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,4 +1,5 @@
 module.exports = {
 	User: require("./user"),
 	App: require("./app"),
+	Organisation: require("./organisation"),
 };

--- a/src/models/organisation.js
+++ b/src/models/organisation.js
@@ -1,0 +1,18 @@
+const mongoose = require("mongoose"),
+	{ Schema } = mongoose;
+
+const orgSchema = new Schema({
+	name: {
+		type: String,
+		required: true,
+		unique: true,
+	},
+	users: [
+		{
+			type: Schema.Types.ObjectId,
+			ref: "User",
+		},
+	],
+});
+
+module.exports = mongoose.model("Organisation", orgSchema);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,53 +1,53 @@
 const mongoose = require("mongoose"),
-   { Schema } = mongoose;
+	{ Schema } = mongoose;
 
 const userSchema = new Schema(
-    {
-        fullname: {
-            type: String,
-            required: true,
-        },
-        organisation_name: {
-            type: String,
-            required: true,
-            unique: true,
-        },
-        email: {
-            type: String,
-            required: true,
-            unique: true,
-        },
-        password: {
-            type: String,
-            required: true,
-        },
-        security_question: {
-            type: String,
-            required: true,
-        },
-        security_answer: {
-            type: String,
-            required: true,
-        },
-        confirmed: {
-            type: Boolean,
-            default: false,
-        },
-        apps: [
-            {
-                type: Schema.Types.ObjectId,
-                ref: 'App',
-            },
-        ],
-        role: {
-            type: String,
-            default: "OWNER",
-        },
-        locations: [String],
-    },
-    {
-        timestamps: true,
-    }
+	{
+		fullname: {
+			type: String,
+			required: true,
+		},
+		organisation: {
+			type: Schema.Types.ObjectId,
+			ref: "Organisation",
+		},
+
+		email: {
+			type: String,
+			required: true,
+			unique: true,
+		},
+		password: {
+			type: String,
+			required: true,
+		},
+		security_question: {
+			type: String,
+			required: true,
+		},
+		security_answer: {
+			type: String,
+			required: true,
+		},
+		confirmed: {
+			type: Boolean,
+			default: false,
+		},
+		apps: [
+			{
+				type: Schema.Types.ObjectId,
+				ref: "App",
+			},
+		],
+		role: {
+			type: String,
+			default: "OWNER",
+		},
+		locations: [String],
+	},
+	{
+		timestamps: true,
+	}
 );
 
 module.exports = mongoose.model("User", userSchema);

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -6,9 +6,11 @@ const {
 	forgotPassword,
 	changePassword,
 	resetPassword,
+	registerByInvite,
 } = require("../controllers/auth.controllers");
 const {
 	userSignUpValidationRules,
+	registerByInviteValidationRules,
 	userSignInValidationRules,
 	resetPasswordValRules,
 	changePasswordValRules,
@@ -20,6 +22,12 @@ authRouter.post(
 	userSignUpValidationRules(),
 	validateError,
 	userSignUp
+);
+authRouter.post(
+	"/register-by-invite",
+	registerByInviteValidationRules(),
+	validateError,
+	registerByInvite
 );
 authRouter.patch("/verify", accountVerification);
 authRouter.post(
@@ -37,9 +45,9 @@ authRouter.patch(
 );
 
 authRouter.post(
-	"/change-password", 
-	changePasswordValRules(), 
-	validateError, 
+	"/change-password",
+	changePasswordValRules(),
+	validateError,
 	changePassword
 );
 

--- a/src/views/adminInviteMail.hbs
+++ b/src/views/adminInviteMail.hbs
@@ -56,10 +56,7 @@
             margin: 2rem 0;
         }
 
-        .section p span {
-            font-weight: 800;
-            text-transform: uppercase;
-        }
+
 
         .section .simple {
             color: #1968c3;
@@ -77,7 +74,7 @@
     <div class="section">
         <h1>APPLICATION ADMIN INVITE EMAIL</h1>
         <p>
-            <span>{{name}}</span>, @{{orgName}} has invited you to be an administrator on
+            <span>Hello there</span>,<a href="#">@{{orgName}}</a> has invited you to be an administrator on
             the <strong>{{appName}}</strong> application.
         </p>
         <p>
@@ -89,7 +86,7 @@
         <p>{{invitationLink}}</p>
 
         <p class="simple">
-            <strong>Note:</strong> This invitation was intended for {{userEmail}}. 
+            <strong>Note:</strong> This invitation was intended for {{userEmail}}.
             If you were not expecting this invitation, you can ignore this email.
         </p>
     </div>


### PR DESCRIPTION

**description of Task to be completed?**

This commit includes modifications to the `user add app_admins` feature. Modifications are summarised below;
   - Invitee necessarily needs not to be registered on gatepass before he's sent an invitation mail
   - Organisations data and users data have been separated
          - Organisation model (new), now includes the name of  the organisation and
            users under the organisation
    - A new controller added: `registerByInvite` handles the  registration of an invitee that has not been initially registered on gatepass


**Any background context you want to provide?**

New model added -- `Organisation model`
New environment Variable added -- `INVITE_SECRET`


